### PR TITLE
updated bacon() to use the 2x2s not beta_hat_b incorrectly 

### DIFF
--- a/R/bacon.R
+++ b/R/bacon.R
@@ -117,12 +117,11 @@ bacon <- function(formula,
       skl <- calculate_weights_controled(data1, treated_group, untreated_group,
                                          V_db)
       
-      beta_hat_d_bkl <- calculate_beta_hat_d_bkl(data1, treated_group, untreated_group)
+      beta_hat_two_by_two <- calculate_beta_hat_22_kl(data1)
       
       two_by_twos[i, "weight"] <- skl
-      two_by_twos[i, "estimate"] <- beta_hat_d_bkl
+      two_by_twos[i, "estimate"] <- beta_hat_two_by_two
     }
-    
     two_by_twos <- scale_weights(two_by_twos)
     
     r_list <- list("beta_hat_w" = beta_hat_w,
@@ -514,4 +513,5 @@ calculate_beta_hat_d_bkl <- function(data, treated_group, untreated_group) {
   N <- nrow(data)
   Vd_bkl <- var(data$d_kt_til)*(N - 1)/N
   beta_hat_d_bkl <- (VD_kl*beta_hat_22_kl - Vp_bkl*beta_hat_p_bkl)/Vd_bkl
+  return(beta_hat_d_bkl)
 }


### PR DESCRIPTION
beta_hat_DD = Sigma * beta_hat_w + (1 - Sigma) * sum(skl * beta_hat_2x2) but we were returning beta_hat_b_d_kl instead of 2x2s I think.

We only care about beta_hat_b_d_kl (or whatever we called it) for testing purposes I think (eqn 26).

Still doesn't fix tests but we're closer which is good I guess?