### PR TITLE
Unbalanced panel

### DIFF
--- a/R/bacon.R
+++ b/R/bacon.R
@@ -59,13 +59,6 @@ bacon <- function(formula,
   control_vars <- vars$control_vars
   data <- rename_vars(data, id_var, time_var, outcome_var, treated_var)
   
-  # Check for a balanced panel
-  bal <- aggregate(time ~ id,  data = data, FUN = length)
-  balanced <- ifelse(all(bal$time == bal$time[1]), 1, 0)
-  if (!balanced) {
-    stop("Unbalanced Panel")
-  }
-  
   # Check for NA observations
   nas <- sum(is.na(data[, c("id", "time", "outcome", "treated")]))
   if (length(control_vars > 0)) {

--- a/tests/testthat/test_bacon_divorce.R
+++ b/tests/testthat/test_bacon_divorce.R
@@ -28,3 +28,5 @@ test_that("Table 1 col 1 Stevenson and Wolfers  Replicates",
               stevenson_wolfson_replicates
             )
           })
+
+## TODO We don't actually test anything related to bacon here...

--- a/tests/testthat/test_errors.R
+++ b/tests/testthat/test_errors.R
@@ -4,12 +4,6 @@
 castle <- bacondecomp::castle
 castle <- castle[-sample(1:nrow(castle), 1), ]
 
-test_that("Unbalanced panel error", {
-  expect_error(bacon(l_homicide ~ post,
-                     data = castle,
-                     id_var = "state",
-                     time_var = "year"), "Unbalanced Panel")
-})
 
 # NA Observations (Uncontrolled)
 castle <- bacondecomp::castle


### PR DESCRIPTION
Removed the `stop()` and associated tests for unbalanced panels since allowing varying group sizes is fine.